### PR TITLE
Fix bugs in setting page

### DIFF
--- a/src/components/settings/settings-page.tsx
+++ b/src/components/settings/settings-page.tsx
@@ -154,8 +154,17 @@ class SettingsPage extends React.Component<SettingsPageProps> {
             </SettingsPagePlaceholder>;
         }
 
-        // ! because we know this is set, as we have a paid user
-        const sub = userSubscription!;
+        // This can be undefined if isPaidUser is set to true by devs
+        let sub = userSubscription;
+
+        if(!sub){
+            sub = {
+                id: 0,
+                status: 'active',
+                plan: 'pro-monthly',
+                expiry: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+            }
+        }
 
         return <SettingsPageScrollContainer>
             <SettingPageContainer>


### PR DESCRIPTION
Without this fix settings page gives:

![Screenshot from 2021-07-24 12-31-29](https://user-images.githubusercontent.com/8097377/126860139-6f8b6516-4edf-4c91-80b0-45fa2bf423ce.png)


After this:
![Screenshot from 2021-07-24 12-32-49](https://user-images.githubusercontent.com/8097377/126860155-110ec634-b1bf-4fb7-86e9-fc9c5a476cb7.png)


Cause:

If we make `isPaidUser` to true in `accountStore` to true (Although it's not recommend and I do have gifted pro subs by author of this repo).

If you see in console we get error it is due to fact the code in settings-page.tsx assumes subs is not undefined.