### PR TITLE
Add localhost:8080 in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ To get started:
 * `npm install`
 * For pure UI development
     * Run `npm start` to start the UI along with a backing [httptoolkit server](https://github.com/httptoolkit/httptoolkit-server).
-    * Open [`local.httptoolkit.tech:8080`](http://local.httptoolkit.tech:8080) to view the UI
+    * Open [`local.httptoolkit.tech:8080`](http://local.httptoolkit.tech:8080) or [`localhost:8080`](http://localhost:8080) to view the UI
 * To develop the UI & server together
     * Start [a server](https://github.com/httptoolkit/httptoolkit-server) locally
     * Run `npm run start:web` to start the UI without running a separate HTTP Toolkit server
-    * Open [`local.httptoolkit.tech:8080`](http://local.httptoolkit.tech:8080) to view the UI
+    * Open [`local.httptoolkit.tech:8080`](http://local.httptoolkit.tech:8080) or [`localhost:8080`](http://localhost:8080) to view the UI
 * `npm test` - run the tests (not many yet, but more are very welcome!)


### PR DESCRIPTION
I don't know why there is local.httptoolkit.tech ( I guess it assumes our proxy is already redirected from the proxy which is usually not the case when we first install httptool-kit-ui?

However, on my end localhost:8080 was running hence the patch.