### PR TITLE
Handle case where local.httptoolkit.com:8080 doesn't seem to work in dev env

### DIFF
--- a/automation/webpack.dev.ts
+++ b/automation/webpack.dev.ts
@@ -10,6 +10,7 @@ export default merge(common, {
 
     devServer: {
         contentBase: common.output!.path!,
+        host: '127.0.0.1',
         public: 'local.httptoolkit.tech:8080',
         historyApiFallback: true
     },


### PR DESCRIPTION
We had a long discussion and after applying this patch it worked on my PC.

So please check on your PC because I don't know how it will behave on windows.

I tested on popos ( Ubuntu derivative)