### PR TITLE
fix: edge case - empty exchanges

### DIFF
--- a/src/model/http/har.ts
+++ b/src/model/http/har.ts
@@ -295,7 +295,7 @@ function getSourcesAsHarPages(exchanges: HttpExchange[]): HarFormat.Page[] {
             'startTime' in e.timingEvents
                 ? e.timingEvents.startTime
                 : Date.now()
-        ));
+        ), Date.now());
 
         return {
             id: source,


### PR DESCRIPTION
I don't even know if it may happen in the normal use-case scenario that
`exchanges` are empty. In this case, `sourceStartTime` will be empty and
`dateFns.format` will complain.

I would love to write a unit-test for this, but running `npm run test`
gives the following output:

```
$ echo $CHROME_BIN
/usr/bin/chromedriver

$ npm run test:unit

> httptoolkit-ui@0.1.0 test:unit
> env-cmd -f ./automation/ts-node.env karma start ./test/unit/karma.conf.js

START:
ℹ ｢wdm｣: Compiled successfully.
ℹ ｢wdm｣: Compiling...
ℹ ｢wdm｣: Compiled successfully.
29 08 2022 13:48:57.863:INFO [karma-server]: Karma v3.1.4 server started at http://0.0.0.0:9876/
29 08 2022 13:48:57.864:INFO [launcher]: Launching browsers ChromeHeadlessNoSandbox with concurrency unlimited
29 08 2022 13:48:57.866:INFO [launcher]: Starting browser ChromeHeadless
29 08 2022 13:49:57.912:WARN [launcher]: ChromeHeadless have not captured in 60000 ms, killing.
29 08 2022 13:49:57.916:INFO [launcher]: Trying to start ChromeHeadless again (1/2).
29 08 2022 13:50:57.975:WARN [launcher]: ChromeHeadless have not captured in 60000 ms, killing.
29 08 2022 13:50:57.979:INFO [launcher]: Trying to start ChromeHeadless again (2/2).
29 08 2022 13:51:57.995:WARN [launcher]: ChromeHeadless have not captured in 60000 ms, killing.
29 08 2022 13:51:57.999:ERROR [launcher]: ChromeHeadless failed 2 times (timeout). Giving up.
```

For context: This is the only tiny fix from my attempt to use `mockttp` as a
forward proxy to intercept network traffic. I used the code in this file to
export a `.har` file.