### PR TITLE
Fix: Make Electron apps available on macOS again

### DIFF
--- a/src/components/intercept/config/electron-config.tsx
+++ b/src/components/intercept/config/electron-config.tsx
@@ -123,7 +123,7 @@ function getReadablePath(path: string) {
 
 declare global {
     interface Window {
-        nativeFile?: { open: () => Promise<string | undefined> };
+        desktopApi?: { selectApplication: () => Promise<string | undefined> };
     }
 }
 
@@ -149,11 +149,13 @@ class ElectronConfig extends React.Component<{
 
     selectApplication = async () => {
         const useNativePicker =
-            platform == 'mac' && window.nativeFile?.open;
+            platform == 'mac' && window.desktopApi?.selectApplication;
 
-        const pathToApplication = await (useNativePicker
-            ? window.nativeFile?.open()
-            : uploadFile('path'));
+        const pathToApplication = await(
+            useNativePicker
+                ? window.desktopApi?.selectApplication()
+                : uploadFile('path')
+        );
 
         if (!pathToApplication) {
             this.props.closeSelf();

--- a/src/components/intercept/config/electron-config.tsx
+++ b/src/components/intercept/config/electron-config.tsx
@@ -149,7 +149,7 @@ class ElectronConfig extends React.Component<{
 
     selectApplication = async () => {
         const useNativePicker =
-            platform == 'win' && window.nativeFile?.open;
+            platform == 'mac' && window.nativeFile?.open;
 
         const pathToApplication = await (useNativePicker
             ? window.nativeFile?.open()

--- a/src/components/intercept/config/electron-config.tsx
+++ b/src/components/intercept/config/electron-config.tsx
@@ -123,7 +123,7 @@ function getReadablePath(path: string) {
 
 declare global {
     interface Window {
-        nativeFile: { open: () => Promise<string | undefined> };
+        nativeFile?: { open: () => Promise<string | undefined> };
     }
 }
 
@@ -149,10 +149,10 @@ class ElectronConfig extends React.Component<{
 
     selectApplication = async () => {
         const useNativePicker =
-            platform == 'win' && window.nativeFile.open;
+            platform == 'win' && window.nativeFile?.open;
 
         const pathToApplication = await (useNativePicker
-            ? window.nativeFile.open()
+            ? window.nativeFile?.open()
             : uploadFile('path'));
 
         if (!pathToApplication) {

--- a/src/components/intercept/config/electron-config.tsx
+++ b/src/components/intercept/config/electron-config.tsx
@@ -121,6 +121,12 @@ function getReadablePath(path: string) {
     }
 }
 
+declare global {
+    interface Window {
+        nativeFile: { open: () => Promise<string | undefined> };
+    }
+}
+
 @inject('uiStore')
 @observer
 class ElectronConfig extends React.Component<{
@@ -142,7 +148,12 @@ class ElectronConfig extends React.Component<{
     }
 
     selectApplication = async () => {
-        const pathToApplication = await uploadFile('path');
+        const useNativePicker =
+            platform == 'win' && window.nativeFile.open;
+
+        const pathToApplication = await (useNativePicker
+            ? window.nativeFile.open()
+            : uploadFile('path'));
 
         if (!pathToApplication) {
             this.props.closeSelf();

--- a/src/components/intercept/config/electron-config.tsx
+++ b/src/components/intercept/config/electron-config.tsx
@@ -148,8 +148,7 @@ class ElectronConfig extends React.Component<{
     }
 
     selectApplication = async () => {
-        const useNativePicker =
-            platform == 'mac' && window.desktopApi?.selectApplication;
+        const useNativePicker = window.desktopApi?.selectApplication;
 
         const pathToApplication = await(
             useNativePicker

--- a/src/components/intercept/config/electron-config.tsx
+++ b/src/components/intercept/config/electron-config.tsx
@@ -194,9 +194,9 @@ class ElectronConfig extends React.Component<{
             </p>
             {
                 platform === 'mac' && previousElectronAppPaths.length < 2 && <p>
-                    For .app bundles, enter either the bundle name (with or without .app)
-                    or the full path to the executable itself, typically stored in
-                    Contents/MacOS inside the bundle.
+                    For .app bundles, you can intercept either the bundle
+                    (the .app directory) or the executable itself,
+                    typically stored in Contents/MacOS inside the bundle.
                 </p>
             }
             <p>

--- a/src/model/interception/interceptors.ts
+++ b/src/model/interception/interceptors.ts
@@ -284,10 +284,6 @@ const INTERCEPT_OPTIONS: _.Dictionary<InterceptorConfig> = {
         description: ["Launch an Electron application with all its traffic intercepted"],
         iconProps: SourceIcons.Electron,
         uiConfig: ElectronCustomUi,
-        checkRequirements: ({ interceptorVersion }) => {
-            return !navigator.platform.startsWith('Mac') &&
-                versionSatisfies(interceptorVersion, "^1.0.1")
-        },
         tags: ['electron', 'desktop', 'postman']
     },
     [MANUAL_INTERCEPT_ID]: {


### PR DESCRIPTION
Requires httptoolkit/httptoolkit-desktop#60, done for httptoolkit/httptoolkit#329