### PR TITLE
Avoid running type checking on library modules for perf

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
         "moduleResolution": "node",
         "outDir": "./dist",
         "sourceMap": true,
+        "skipLibCheck": true,
 
         "jsx": "react",
         "experimentalDecorators": true,


### PR DESCRIPTION
https://www.typescriptlang.org/tsconfig#skipLibCheck

help the type checking startup speeds at the slight risk of type collisions.  