### PR TITLE
Feat header include exclude context menu

### DIFF
--- a/src/components/send/sent-response-headers.tsx
+++ b/src/components/send/sent-response-headers.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 
 import { RawHeaders } from '../../types';
+import {IncludeExcludeList} from '../../model/IncludeExcludeList';
+
 
 import {
     CollapsibleCardHeading,
@@ -16,6 +18,7 @@ export interface ResponseHeaderSectionProps extends ExpandableCardProps {
     requestUrl: URL;
     headers: RawHeaders;
 }
+const HeadersIncludeExcludeList = new IncludeExcludeList<string>();
 
 export const SentResponseHeaderSection = ({
     requestUrl,
@@ -34,7 +37,7 @@ export const SentResponseHeaderSection = ({
                 Response Headers
             </CollapsibleCardHeading>
         </header>
-        <HeaderDetails
+        <HeaderDetails HeadersIncludeExcludeList={HeadersIncludeExcludeList}
             requestUrl={requestUrl}
             headers={headers}
         />

--- a/src/components/view/http/headers-context-menu-builder.ts
+++ b/src/components/view/http/headers-context-menu-builder.ts
@@ -1,0 +1,111 @@
+import { action, runInAction } from 'mobx';
+
+
+import { AccountStore } from '../../../model/account/account-store';
+import { UiStore } from '../../../model/ui/ui-store';
+
+import { IEList, IncludeExcludeList } from '../../../model/IncludeExcludeList';
+
+import { copyToClipboard } from '../../../util/ui';
+import { ContextMenuItem } from '../../../model/ui/context-menu';
+
+
+
+
+export interface HeadersHeaderClickedData {
+    HeadersIncludeExcludeList : IncludeExcludeList<string>
+}
+
+export interface HeaderEvent {
+	HeadersIncludeExcludeList: IncludeExcludeList<string>,
+	header_name: string;
+	header_value: string[];
+}
+
+export class HeadersHeaderContextMenuBuilder {
+
+    constructor(
+        private uiStore: UiStore
+    ) {}
+
+    getContextMenuCallback(event: HeadersHeaderClickedData) {
+        return (mouseEvent: React.MouseEvent) => {
+			let excluded = event.HeadersIncludeExcludeList.GetKeysOnList(IEList.Exclude);
+
+			this.uiStore.handleContextMenuEvent(mouseEvent, [
+
+				{
+					type: 'submenu',
+					enabled: excluded.length > 0,
+					label: `Excluded`,
+					items: [
+						{
+							type: 'option',
+							label: `Clear All Excluded Headers`,
+							callback: async (data) => data.HeadersIncludeExcludeList.ClearList(IEList.Exclude)
+							
+						},
+						...
+						(excluded.map((headerName) => ({
+
+                                type: 'option',
+                                label: `Clear '${headerName}'`,
+                                callback: async (data: HeadersHeaderClickedData) => 
+								data.HeadersIncludeExcludeList.RemoveFromList(headerName,IEList.Exclude)
+                                    
+                                    
+                                }
+                            ))
+							 ) as ContextMenuItem<HeadersHeaderClickedData>[]
+					]
+				}
+
+
+			], event
+           
+			);
+        };
+    }
+}
+
+export class HeadersContextMenuBuilder {
+
+    constructor(
+        private accountStore: AccountStore,
+        private uiStore: UiStore
+    ) {}
+
+    getContextMenuCallback(event: HeaderEvent) {
+        return (mouseEvent: React.MouseEvent) => {
+            const { isPaidUser } = this.accountStore;
+			let isPinned = event.HeadersIncludeExcludeList.IsKeyOnList(event.header_name,IEList.Favorite);
+
+			this.uiStore.handleContextMenuEvent(mouseEvent,  [
+				{
+					type: 'option',
+					label: (isPinned ? `Unpin` : `Pin`) + ` This Header`,
+					callback: async (data) => {
+						isPinned ? data.HeadersIncludeExcludeList.RemoveFromList(data.header_name,IEList.Favorite) : data.HeadersIncludeExcludeList.AddOrUpdateToList(data.header_name,IEList.Favorite);
+					}
+				},
+				{
+					type: 'option',
+					label: `Exclude This Header`,
+					callback: async (data) => {
+						data.HeadersIncludeExcludeList.AddOrUpdateToList(data.header_name,IEList.Exclude);
+					}
+				},
+				{
+					type: 'option',
+					label: `Copy Header Value`,
+					callback: async (data) => copyToClipboard( data.header_value.join("\n" ) )
+						
+					
+				}
+
+			], event
+           
+			);
+        };
+    }
+}

--- a/src/components/view/http/http-request-card.tsx
+++ b/src/components/view/http/http-request-card.tsx
@@ -12,6 +12,8 @@ import { getSummaryColour } from '../../../model/events/categorization';
 import { getMethodDocs } from '../../../model/http/http-docs';
 import { nameHandlerClass } from '../../../model/rules/rule-descriptions';
 import { HandlerClassKey } from '../../../model/rules/rules';
+import {IEList, IncludeExcludeList} from '../../../model/IncludeExcludeList';
+import { HeadersHeaderContextMenuBuilder, HeaderEvent } from './headers-context-menu-builder';
 
 import {
     CollapsibleCardHeading,
@@ -87,7 +89,10 @@ const MatchedRulePill = styled(inject('uiStore')((p: {
     }
 `;
 
-const RawRequestDetails = (p: { request: HtkRequest }) => {
+const HeadersIncludeExcludeList = new IncludeExcludeList<string>();
+
+const RawRequestDetails = (p: { request: HtkRequest, contextMenuBuilder: HeadersHeaderContextMenuBuilder, uiStore : UiStore }) => {
+
     const methodDocs = getMethodDocs(p.request.method);
     const methodDetails = [
         methodDocs && <Markdown
@@ -131,14 +136,14 @@ const RawRequestDetails = (p: { request: HtkRequest }) => {
                 </CollapsibleSectionBody>
             }
         </CollapsibleSection>
-
-        <ContentLabelBlock>Headers</ContentLabelBlock>
-        <HeaderDetails headers={p.request.rawHeaders} requestUrl={p.request.parsedUrl} />
+        <ContentLabelBlock onContextMenu={p.contextMenuBuilder.getContextMenuCallback({HeadersIncludeExcludeList})}>Headers</ContentLabelBlock>
+        <HeaderDetails uiStore={p.uiStore} headers={p.request.rawHeaders} HeadersIncludeExcludeList={HeadersIncludeExcludeList} requestUrl={p.request.parsedUrl} />
     </div>;
 }
 
 interface HttpRequestCardProps extends CollapsibleCardProps {
     exchange: HttpExchange;
+    uiStore?: UiStore;
     matchedRuleData: {
         stepTypes: HandlerClassKey[],
         status: 'unchanged' | 'modified-types' | 'deleted'
@@ -146,9 +151,13 @@ interface HttpRequestCardProps extends CollapsibleCardProps {
     onRuleClicked: () => void;
 }
 
-export const HttpRequestCard = observer((props: HttpRequestCardProps) => {
+export const HttpRequestCard = inject('uiStore') (observer((props: HttpRequestCardProps) => {
     const { exchange, matchedRuleData, onRuleClicked } = props;
     const { request } = exchange;
+    const contextMenuBuilder = new HeadersHeaderContextMenuBuilder(
+        props.uiStore!
+    );
+
 
     // We consider passthrough as a no-op, and so don't show anything in that case.
     const noopRule = matchedRuleData?.stepTypes.every(
@@ -177,6 +186,6 @@ export const HttpRequestCard = observer((props: HttpRequestCardProps) => {
             </CollapsibleCardHeading>
         </header>
 
-        <RawRequestDetails request={request} />
+        <RawRequestDetails uiStore={props.uiStore!} request={request} contextMenuBuilder={contextMenuBuilder} />
     </CollapsibleCard>;
-});
+}));

--- a/src/components/view/http/http-response-card.tsx
+++ b/src/components/view/http/http-response-card.tsx
@@ -1,12 +1,14 @@
 import * as _ from 'lodash';
 import * as React from 'react';
-import { observer } from 'mobx-react';
+
+import { inject, observer } from 'mobx-react';
 import { get } from 'typesafe-get';
 
 import { HtkResponse, Omit } from '../../../types';
 import { Theme } from '../../../styles';
 
 import { ApiExchange } from '../../../model/api/api-interfaces';
+import { UiStore } from '../../../model/ui/ui-store';
 import { getStatusColor } from '../../../model/events/categorization';
 import { getStatusDocs, getStatusMessage } from '../../../model/http/http-docs';
 
@@ -17,6 +19,8 @@ import {
 } from '../../common/card';
 import { Pill } from '../../common/pill';
 import { HeaderDetails } from './header-details';
+import { HeadersHeaderContextMenuBuilder, HeaderEvent } from './headers-context-menu-builder';
+import {IEList, IncludeExcludeList} from '../../../model/IncludeExcludeList';
 import {
 } from '../../common/card';
 import {
@@ -35,12 +39,18 @@ import { DocsLink } from '../../common/docs-link';
 interface HttpResponseCardProps extends CollapsibleCardProps  {
     theme: Theme;
     requestUrl: URL;
+    uiStore?: UiStore;
     response: HtkResponse;
     apiExchange: ApiExchange | undefined;
 }
+const HeadersIncludeExcludeList = new IncludeExcludeList<string>();
 
-export const HttpResponseCard = observer((props: HttpResponseCardProps) => {
+export const HttpResponseCard = inject('uiStore') (observer((props: HttpResponseCardProps) => {
     const { response, requestUrl, theme, apiExchange } = props;
+
+    const contextMenuBuilder = new HeadersHeaderContextMenuBuilder(
+        props.uiStore!
+    );
 
     const apiResponseDescription = get(apiExchange, 'response', 'description');
     const statusDocs = getStatusDocs(response.statusCode);
@@ -84,9 +94,8 @@ export const HttpResponseCard = observer((props: HttpResponseCardProps) => {
                     : null
                 }
             </CollapsibleSection>
-
-            <ContentLabelBlock>Headers</ContentLabelBlock>
-            <HeaderDetails headers={response.rawHeaders} requestUrl={requestUrl} />
+            <ContentLabelBlock  onContextMenu={contextMenuBuilder.getContextMenuCallback({HeadersIncludeExcludeList})}>Headers</ContentLabelBlock>
+            <HeaderDetails headers={response.rawHeaders} requestUrl={requestUrl} HeadersIncludeExcludeList={HeadersIncludeExcludeList} uiStore={props.uiStore}  />
         </div>
     </CollapsibleCard>;
-});
+}));

--- a/src/model/IncludeExcludeList.ts
+++ b/src/model/IncludeExcludeList.ts
@@ -1,0 +1,96 @@
+import * as _ from 'lodash';
+
+export enum IEList { //these are flags so no direct equals, nothing requires them to be used as flags, but it would allow you to have an entry on both Include and Favorite at the same type
+	Invalid = 0,
+	Include = 1 << 1,
+	Exclude = 1 << 2,
+	Favorite = 1 << 3,
+}
+
+function* mapIterableImpl<T, U>(f: (val: T) => U, iterable: Iterable<T>): Iterable<U> {
+	for (const item of iterable) {
+		yield f(item);
+	}
+}
+const mapIterable = <T, U>(f: (val: T) => U) => (iterable: Iterable<T>) => mapIterableImpl(f, iterable);
+function* filterIterableImpl<T>(f: (item: T) => boolean, iterable: Iterable<T>): Iterable<T> {
+	for (const item of iterable) {
+	  if (f(item)) {
+		yield item;
+	  }
+	}
+  }
+const filterIterable = <T>(f: (val: T) => boolean) => (iterable: Iterable<T>) => filterIterableImpl(f, iterable);
+
+interface SerializeData<ListKeyType>{
+	known : Map<ListKeyType, IEList>;
+}
+type ItemResolver<T, TResult> = (value: T) => TResult;
+
+export class IncludeExcludeList<ListKeyType> {
+
+	protected known = new Map<ListKeyType, IEList>();
+
+	GetSaveDataObject() : Object {
+		return {known:new Map(this.known)} as SerializeData<ListKeyType>;
+	}
+	static LoadFromSaveDataObject<ListKeyType>(object : object) : IncludeExcludeList<ListKeyType> {
+		let ret = new IncludeExcludeList<ListKeyType>();
+		ret.known = new Map((object as SerializeData<ListKeyType>).known);
+		return ret;
+	}
+
+	AddOrUpdateToList = (key: ListKeyType, list: IEList) => this.known.set(key, list);
+	RemoveFromLists = (key: ListKeyType) => this.known.delete(key);
+	ClearList(list: IEList){
+		let keys = this.GetKeysOnList(list);
+		for (const key of keys)
+			this.RemoveFromList(key,list);
+	}
+	RemoveFromList(key: ListKeyType, list: IEList){
+		let current = this.GetKeyList(key);
+		if (current == undefined)
+			return;
+		current &= ~list;
+		if (current == IEList.Invalid)
+			this.known.delete(key);
+		else
+			this.AddOrUpdateToList(key, current);
+	}
+	
+	GetKeyList = (key: ListKeyType) => this.known.get(key);
+	GetKeysOnList(list: IEList) : ListKeyType[] {
+		  let filtered = filterIterable((kvp : [ListKeyType, IEList]) => (kvp[1] & list) != 0)(this.known.entries());
+		  let mapped = mapIterable((kvp : [ListKeyType, IEList]) => kvp[0])(filtered);
+		  return Array.from( mapped );
+	}
+	IsKeyOnList(key : ListKeyType, list: IEList, trueIfUnknown : boolean = false){
+		let val = this.GetKeyList(key);
+		if (val === undefined)
+			return trueIfUnknown;
+		return (val & list) != 0;
+	}
+
+	/// returnUnknown true if you want items not on any list, false if they should be excluded
+	FilterArrayAgainstList<T>(arr: Iterable<T>, list: IEList, returnUnknown : boolean = false, resolver : ItemResolver<T,ListKeyType>|undefined=undefined) : Iterable<T>{
+		if (!resolver)
+			resolver = (itm) => itm as any;
+		return filterIterable( (key : T) => this.IsKeyOnList(resolver!(key),list,returnUnknown))(arr);
+	}
+
+	/// return the list in the same order passed in except all items that are on the specified list are returned first
+	* SortArrayAgainstList<T>(arr: Iterable<T>, list: IEList, resolver : ItemResolver<T,ListKeyType>|undefined=undefined) : IterableIterator<T> {
+		let after = new Array() as Array<T>;
+		if (! resolver)
+			resolver = (itm) => itm as any;
+		for (const item of arr) {
+			if (this.IsKeyOnList(resolver(item),list))
+				yield item;
+			else
+				after.push(item);
+		}
+		for (const itm of after)
+			yield itm;
+	}
+
+}


### PR DESCRIPTION
I tried to follow the structuring / view / model format you used for the other context menu, so should at least be closer to correct:) 

There is no auto-refresh of the header list when you pin/exclude something maybe the re-render should be called.

Excluded headers could be in an already collapsed CollapsibleSection rather than totally not visible, although i think this works just fine.

I in-vision CollapsibleCard could be changed to be a tri-state component instead.  Rather than just expanded or collapsed it could also only show the currently pinned headers, sort of a compact form.

I added load/save handlers to the more generalized IncludeExcludeList class.  I think there is persistent data with httptoolkit (probably just premium only) and I haven't fooled with that at all so I didn't actually hook them up to any serializer to save them to w/e persistent store.

IncludeExcludeList is somewhat generalized in the list data type but hardcoded to the `IEList` enum for the lists themselves.   It could be added as a second generic parameter instead to expand beyond the limited 3 mentioned.  Granted it could just add more added, as nothing requires a implementer to use all the lists it supports.

I like the more dynamic implementation of the context menu code, allowed me to do the on the fly generation for currently excluded headers so you can clear just one at a time easily.