### PR TITLE
Remove glob character in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "src"
   ],
   "scripts": {
-    "prebuild": "rimraf dist/*",
+    "prebuild": "rimraf dist",
     "build": "run-script-os",
     "build:default": "env-cmd -f ./automation/ts-node.env.js node --max_old_space_size=4096 node_modules/.bin/webpack --config ./automation/webpack.prod.ts",
     "build:windows": "env-cmd -f ./automation/ts-node.env.js node --max_old_space_size=4096 node_modules/webpack/bin/webpack.js --config ./automation/webpack.prod.ts",


### PR DESCRIPTION
As it is not needed and because it cause crash (only) on windows, and so when building.