### PR TITLE
Add automatic theme (syncs with system settings)

### DIFF
--- a/src/components/common/tabbed-options.tsx
+++ b/src/components/common/tabbed-options.tsx
@@ -15,10 +15,9 @@ interface TabClickEvent extends React.MouseEvent {
 }
 
 export const TabsContainer = styled((p: {
-    onClick: (tabValue: any) => void;
-    isSelected: (value: any) => boolean;
-    children: Array<React.ReactElement<any, typeof Tab>>;
-    disabled?: boolean;
+    onClick: (tabValue: any) => void,
+    isSelected: (value: any) => boolean,
+    children: Array<React.ReactElement<any, typeof Tab>>
 }) => <nav
     {...omit(p, 'isSelected')}
     onClick={(event: TabClickEvent) => {
@@ -41,11 +40,6 @@ export const TabsContainer = styled((p: {
     flex-direction: column;
     justify-content: center;
     align-items: flex-start;
-
-    ${p => p.disabled && css`
-        opacity: 0.5;
-        pointer-events: none;
-    `}
 `;
 
 export const Tab = styled((p: {

--- a/src/components/common/tabbed-options.tsx
+++ b/src/components/common/tabbed-options.tsx
@@ -15,9 +15,10 @@ interface TabClickEvent extends React.MouseEvent {
 }
 
 export const TabsContainer = styled((p: {
-    onClick: (tabValue: any) => void,
-    isSelected: (value: any) => boolean,
-    children: Array<React.ReactElement<any, typeof Tab>>
+    onClick: (tabValue: any) => void;
+    isSelected: (value: any) => boolean;
+    children: Array<React.ReactElement<any, typeof Tab>>;
+    disabled?: boolean;
 }) => <nav
     {...omit(p, 'isSelected')}
     onClick={(event: TabClickEvent) => {
@@ -40,6 +41,11 @@ export const TabsContainer = styled((p: {
     flex-direction: column;
     justify-content: center;
     align-items: flex-start;
+
+    ${p => p.disabled && css`
+        opacity: 0.5;
+        pointer-events: none;
+    `}
 `;
 
 export const Tab = styled((p: {

--- a/src/components/settings/settings-page.tsx
+++ b/src/components/settings/settings-page.tsx
@@ -86,15 +86,11 @@ const AccountContactFooter = styled.div`
     }
 `;
 
-const ThemeAutoButton = styled(SettingsButton)`
-    margin: 10px 0;
-`;
-
 const ThemeColors = styled.div`
     display: grid;
     grid-template-columns: 1fr 1fr;
     border: 3px solid #999;
-    margin: 0 20px;
+    margin: auto 20px;
 `;
 
 const ThemeColorBlock = styled.div<{ themeColor: keyof Theme }>`
@@ -107,6 +103,7 @@ const EditorContainer = styled.div`
     border: 3px solid #999;
     height: 300px;
     flex-grow: 1;
+    margin: auto 0;
 `;
 
 const AccountUpdateSpinner = styled(Icon).attrs(() => ({
@@ -290,21 +287,23 @@ class SettingsPage extends React.Component<SettingsPageProps> {
                                 Themes
                             </CollapsibleCardHeading>
                         </header>
-                        <ThemeAutoButton onClick={uiStore.toggleAutoTheme}>
-                            {uiStore.autoTheme ?  'Use specific theme' : 'Use automatic theme'}
-                        </ThemeAutoButton>
                         <TabbedOptionsContainer>
                             <TabsContainer
-                                disabled={uiStore.autoTheme}
-                                onClick={(value: ThemeName | Theme) => uiStore.setTheme(value)}
-                                isSelected={(value: ThemeName | Theme) => {
+                                onClick={(value: ThemeName | 'automatic' | Theme) => uiStore.setTheme(value)}
+                                isSelected={(value: ThemeName | 'automatic' | Theme) => {
                                     if (typeof value === 'string') {
-                                        return uiStore.themeName === value
+                                        return uiStore.themeName === value;
                                     } else {
                                         return _.isEqual(value, uiStore.theme);
                                     }
                                 }}
                             >
+                                <Tab
+                                    icon={['fas', 'magic']}
+                                    value='automatic'
+                                >
+                                    Automatic
+                                </Tab>
                                 <Tab
                                     icon={['fas', 'sun']}
                                     value='light'

--- a/src/components/settings/settings-page.tsx
+++ b/src/components/settings/settings-page.tsx
@@ -86,6 +86,10 @@ const AccountContactFooter = styled.div`
     }
 `;
 
+const ThemeAutoButton = styled(SettingsButton)`
+    margin: 10px 0;
+`;
+
 const ThemeColors = styled.div`
     display: grid;
     grid-template-columns: 1fr 1fr;
@@ -286,8 +290,12 @@ class SettingsPage extends React.Component<SettingsPageProps> {
                                 Themes
                             </CollapsibleCardHeading>
                         </header>
+                        <ThemeAutoButton onClick={uiStore.toggleAutoTheme}>
+                            {uiStore.autoTheme ?  'Use specific theme' : 'Use automatic theme'}
+                        </ThemeAutoButton>
                         <TabbedOptionsContainer>
                             <TabsContainer
+                                disabled={uiStore.autoTheme}
                                 onClick={(value: ThemeName | Theme) => uiStore.setTheme(value)}
                                 isSelected={(value: ThemeName | Theme) => {
                                     if (typeof value === 'string') {
@@ -311,7 +319,7 @@ class SettingsPage extends React.Component<SettingsPageProps> {
                                 </Tab>
                                 <Tab
                                     icon={['fas', 'adjust']}
-                                    value={'high-contrast'}
+                                    value='high-contrast'
                                 >
                                     High Contrast
                                 </Tab>

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -37,6 +37,7 @@ import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons/faExcla
 import { faLightbulb } from '@fortawesome/free-solid-svg-icons/faLightbulb';
 import { faCog } from '@fortawesome/free-solid-svg-icons/faCog';
 import { faStar } from '@fortawesome/free-regular-svg-icons/faStar';
+import { faMagic } from '@fortawesome/free-solid-svg-icons/faMagic';
 import { faSun } from '@fortawesome/free-solid-svg-icons/faSun';
 import { faMoon } from '@fortawesome/free-solid-svg-icons/faMoon';
 import { faAdjust } from '@fortawesome/free-solid-svg-icons/faAdjust';
@@ -114,6 +115,7 @@ library.add(
     faLightbulb,
     faCog,
     faStar,
+    faMagic,
     faSun,
     faMoon,
     faAdjust,


### PR DESCRIPTION
Hi :)
This adds an option to follow the systems color theme. If theme is changed in system settings, HTTP Toolkit will automatically adapt (if enabled).