### PR TITLE
Feat: Initial multi-select support for events

### DIFF
--- a/src/components/view/http/http-details-footer.tsx
+++ b/src/components/view/http/http-details-footer.tsx
@@ -93,6 +93,7 @@ export const HttpDetailsFooter = inject('rulesStore')(
 
             event: CollectedEvent,
             onDelete: (event: CollectedEvent) => void,
+            onPin: (event: CollectedEvent) => void,
             onScrollToEvent: (event: CollectedEvent) => void,
             onBuildRuleFromExchange: (event: HttpExchange) => void,
             isPaidUser: boolean,
@@ -107,9 +108,7 @@ export const HttpDetailsFooter = inject('rulesStore')(
                 />
                 <PinButton
                     pinned={pinned}
-                    onClick={action(() => {
-                        event.pinned = !event.pinned;
-                    })}
+                    onClick={() => props.onPin(event)}
                 />
                 <DeleteButton
                     pinned={pinned}

--- a/src/components/view/http/http-details-pane.tsx
+++ b/src/components/view/http/http-details-pane.tsx
@@ -66,6 +66,7 @@ export class HttpDetailsPane extends React.Component<{
 
     navigate: (path: string) => void,
     onDelete: (event: CollectedEvent) => void,
+    onPin: (event: CollectedEvent) => void,
     onScrollToEvent: (event: CollectedEvent) => void,
     onBuildRuleFromExchange: (exchange: HttpExchange) => void,
 
@@ -83,6 +84,7 @@ export class HttpDetailsPane extends React.Component<{
         const {
             exchange,
             onDelete,
+            onPin,
             onScrollToEvent,
             onBuildRuleFromExchange,
             uiStore,
@@ -129,6 +131,7 @@ export class HttpDetailsPane extends React.Component<{
             <HttpDetailsFooter
                 event={exchange}
                 onDelete={onDelete}
+                onPin={onPin}
                 onScrollToEvent={onScrollToEvent}
                 onBuildRuleFromExchange={onBuildRuleFromExchange}
                 navigate={navigate}

--- a/src/components/view/view-event-list-buttons.tsx
+++ b/src/components/view/view-event-list-buttons.tsx
@@ -28,6 +28,7 @@ export const ClearAllButton = observer((props: {
 
 export const ExportAsHarButton = inject('accountStore')(observer((props: {
     className?: string,
+    isMultiSelectEnabled: boolean,
     accountStore?: AccountStore,
     events: CollectedEvent[]
 }) => {
@@ -45,8 +46,9 @@ export const ExportAsHarButton = inject('accountStore')(observer((props: {
         }
         disabled={!isPaidUser || props.events.length === 0}
         onClick={async () => {
+            const serialize = props.isMultiSelectEnabled ? props.events.filter(evt=> evt.mulitSelected) : props.events;
             const harContent = JSON.stringify(
-                await generateHar(props.events)
+                await generateHar(serialize)
             );
             const filename = `HTTPToolkit_${
                 dateFns.format(Date.now(), 'YYYY-MM-DD_HH-mm')

--- a/src/components/view/view-event-list-footer.tsx
+++ b/src/components/view/view-event-list-footer.tsx
@@ -61,6 +61,7 @@ export const ViewEventListFooter = styled(observer((props: {
     onClear: () => void,
     onFiltersConsidered: (filters: FilterSet | undefined) => void,
     onScrollToEnd: () => void,
+    isMultiSelectEnabled: boolean,
 
     allEvents: CollectedEvent[],
     filteredEvents: CollectedEvent[],
@@ -87,7 +88,7 @@ export const ViewEventListFooter = styled(observer((props: {
     <ButtonsContainer>
         <PlayPauseButton />
         <ScrollToEndButton onScrollToEnd={props.onScrollToEnd} />
-        <ExportAsHarButton events={props.filteredEvents} />
+        <ExportAsHarButton events={props.filteredEvents} isMultiSelectEnabled={props.isMultiSelectEnabled} />
         <ImportHarButton />
         <ClearAllButton
             disabled={props.allEvents.length === 0}

--- a/src/model/events/event-base.ts
+++ b/src/model/events/event-base.ts
@@ -1,4 +1,4 @@
-import { observable, computed } from 'mobx';
+import { observable, computed, action } from 'mobx';
 
 import {
     FailedTlsConnection,
@@ -37,6 +37,14 @@ export abstract class HTKEventBase {
 
     @observable
     public pinned: boolean = false;
+
+    @observable
+    public mulitSelected: boolean = false;
+
+    @action.bound
+    onMultiSelected(evt : any){
+        this.mulitSelected = ! this.mulitSelected;
+    }
 
     // Logic elsewhere can put values into these caches to cache calculations
     // about this event weakly, so they GC with the event.

--- a/src/model/events/events-store.ts
+++ b/src/model/events/events-store.ts
@@ -169,6 +169,9 @@ export class EventsStore {
     @observable
     isPaused = false;
 
+    @observable
+    isMultiSelectEnabled = false;
+
     private eventQueue: Array<QueuedEvent> = [];
     private orphanedEvents: { [id: string]: OrphanableQueuedEvent<any> } = {};
 


### PR DESCRIPTION
Pin/Delete/Export/Create Rules all work as expected
Closes https://github.com/httptoolkit/httptoolkit/issues/76

This adds a draft/sample for multi-select for rows, not sure if this is the direction one wants to go so certainly is not polished. 

## It implements:
- standard windows explorer control/shift behavior for selecting
- Exporting selected rows to HAR
- Deleting selected rows
- (un)Pinning selected rows
- Creating mock rules for selected rows
- Only enabled when the checkbox column is checked
- Context menu options should work as well due to how they are bound.
- makes onPin behave like onDelete for central behavior purposes

## Things that should be done:
- Keep track of what rows are selected, this would prevent some of the constant enumerating, and more importantly give a count number of how many are selected that could be used other places (context menus, etc rather than saying 'Delete This Rule, Delete 5 rules', show on the right view pane also a count of how many are selected when > 1

- Updating titles/context menu text to reflect multiple events selected

- There is an actual checkbox mode can be enabled with setting USE_MULTI_SELECT_CHECKBOXES=true in view-event-list.ts.  This enables standard checkboxes next to each row.  This might be useful for people in the same way file explorer can have checkboxes enabled, also for mobile (is there mobile ?)

- The multiSelected rows that are not the actual selection have the background/foreground set to the same as the selected row just without the bold.  By default though this difference is hard to notice unless on high contrast, something should be changed for the CSS for this.

- OnDelete might be slightly hokey given it runs all the delete logic for selecting the next event after deleting each event but seems to work (mass scale though might hit perf issues).

- The export to HAR is hokey, by default the buttons for actions are the right side buttons, but there is no singular export to har button so I used the main button rather than add a new one.  Downside is if you enable multi-select (check the box in the column header) then click on just one random event and go to export it exports one not all.  Likely a har button added to the right side for when mutli-events are selected would be good.

- It uses the filtered events for nearly all queries/actions.  This may not make sense, especially where things that are filtered, then multiSelected, then not shown in the current filter stay selected.  They should likely have the selection cleared.  For what events most actions effect GetMultiselectSelectedBulkEvents handles the initial filtering to make it easier to adjust that pattern.  view-event-list-buttons should use GetMultiselectSelectedBulkEvents but doesn't as I wasn't sure the best way to surface it other than passing the function all the way down the calls.

- Right clicking to use a context menu when multi-select is enabled on a non multi-selected row can produce interesting results as it generally effects all selected items + row you are calling the menu on.

- Technically you can multi-select some rows, control click a row then control + click it again to deselect it and the right pane goes away so you can't do most actions through that, even though there are still rows selected.

- The checkbox alignment is the header uses some negative margin alignment.  This was mainly done for when USE_MULTI_SELECT_CHECKBOXES is enabled it only takes up more space on each row when the checkbox in the header is clicked.

- Keyboard multi-select was not implemented but is fairly straightforward.

- Standard I don't know react so things certainly may not be done optimally. My few methods with *actual* in the name are poor form, but allows for minimal changes so should be refactored.  The RowCheckbox in view-event-list in particular is a bit odd: first to be able to use a more contextually correct name of onChecked than onChanged for the event, I had to name it whenChanged otherwise react whines. Secondly I had to double specify the type for the props which I don't think I should have to do but couldn't figure out another way without creating the interface and using it.





