### PR TITLE
fix: updated boolean for 'disable_session_recording' from false to true

### DIFF
--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -27,7 +27,7 @@ export function initMetrics() {
             capture_pageview: false, // We manually capture pageviews (to sanitize & dedupe URLs)
 
             advanced_disable_decide: true, // We don't need dynamic features, skip checking
-            disable_session_recording: false, // Disabled server-side, but disable explicitly here too
+            disable_session_recording: true, // Disabled server-side, but disable explicitly here too
 
             persistence: 'memory' // No cookies/local storage tracking - just anon session metrics
         });


### PR DESCRIPTION
Per [PostHog documentation](https://posthog.com/docs/session-replay/installation#step-two-enable-session-recordings-in-your-project-settings), `disable_session_recording` needs to be set to `true` in order to turn off the feature. The original comment has indicated that the intention is to not record sessions, so this PR is just to fix the misconfiguration.