### PR TITLE
Fix unreadable text in auth0 flow

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -321,6 +321,11 @@ export const GlobalStyles = createGlobalStyle`
                 font-size: ${fontSizes.textSize} !important;
             }
         }
+        
+        /* Override auth0 text entry foreground to avoid black text against a dark background */
+        .auth0-lock-input {
+            color: rgba(255, 255, 255, 1) !important;
+        }
     }
 
     /* Override some Monaco CSS internals */

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -322,9 +322,10 @@ export const GlobalStyles = createGlobalStyle`
             }
         }
         
-        /* Override auth0 text entry foreground to avoid black text against a dark background */
+        /* Override auth0 input to fix unreadable text */
         .auth0-lock-input {
-            color: rgba(255, 255, 255, 1) !important;
+            background-color: rgba(255, 255, 255, 1); !important
+            color: rgba(0, 0, 0, 1) !important;
         }
     }
 


### PR DESCRIPTION
Auth0 fields were showing black text against a dark text entry field. This overrides the class for those text entry foreground colors to white.

| Before | After |
|--------|-------|
| ![firefox_WfXH7Oy6Bf](https://github.com/user-attachments/assets/53da4a7b-fbc9-4e99-a0df-033734f01a92) | ![firefox_VFmXauxSLN](https://github.com/user-attachments/assets/cf4e17c6-b401-4d4f-9158-2c61c62979c8) |