### PR TITLE
Order HAR exports chronologically

### DIFF
--- a/src/model/http/har.ts
+++ b/src/model/http/har.ts
@@ -83,6 +83,12 @@ export interface HarEntry extends HarFormat.Entry {
     _pinned?: true;
 }
 
+const compareHarEntryStartTimes = (
+    a: Pick<HarFormat.Entry, 'startedDateTime'>,
+    b: Pick<HarFormat.Entry, 'startedDateTime'>
+) => dateFns.parse(a.startedDateTime).getTime() -
+    dateFns.parse(b.startedDateTime).getTime();
+
 export interface HarWebSocketMessage {
     type: 'send' | 'receive';
     opcode: 1 | 2;
@@ -119,7 +125,9 @@ export async function generateHar(
     const errors = otherEvents.filter(e => e.isTlsFailure()) as FailedTlsConnection[];
 
     const sourcePages = getSourcesAsHarPages(exchanges);
-    const entries = await Promise.all(exchanges.map(e => generateHarHttpEntry(e, options)));
+    const entries = (await Promise.all(
+        exchanges.map(e => generateHarHttpEntry(e, options))
+    )).sort(compareHarEntryStartTimes);
     const errorEntries = errors.map(generateHarTlsError);
 
     return {
@@ -529,11 +537,7 @@ export async function parseHar(harContents: unknown): Promise<ParsedHar> {
     const pinnedIds: string[] = []
 
     har.log.entries
-    .sort((a, b) => {
-        const aStartTime = dateFns.parse(a.startedDateTime).getTime();
-        const bStartTime = dateFns.parse(b.startedDateTime).getTime();
-        return aStartTime - bStartTime;
-    })
+    .sort(compareHarEntryStartTimes)
     .forEach((entry, i) => {
         const id = baseId + i;
         const isWebSocket = entry._resourceType === 'websocket';

--- a/test/unit/model/http/har.spec.ts
+++ b/test/unit/model/http/har.spec.ts
@@ -1,0 +1,19 @@
+import { expect } from '../../../test-setup';
+
+import { generateHar } from '../../../../src/model/http/har';
+import { getExchangeData } from '../../unit-test-helpers';
+
+describe('HAR generation', () => {
+    it('orders entries chronologically regardless of selection order', async () => {
+        const olderExchange = getExchangeData({ statusCode: 403 });
+        olderExchange.timingEvents.startTime = Date.parse('2026-07-17T20:35:23.997+01:00');
+
+        const newerExchange = getExchangeData({ statusCode: 200 });
+        newerExchange.timingEvents.startTime = Date.parse('2026-07-17T20:36:12.733+01:00');
+
+        const har = await generateHar([newerExchange, olderExchange]);
+
+        expect(har.log.entries.map(entry => entry.response.status))
+            .to.deep.equal([403, 200]);
+    });
+});


### PR DESCRIPTION
## Summary

- sort generated HAR entries by `startedDateTime`
- reuse the same chronological comparator when importing HAR files
- add a regression test for reverse-ordered multi-selection exports

## Why

Multi-selected events are intentionally stored in selection order. Selecting requests from newest to oldest therefore passed a reverse-chronological array to HAR generation, which preserved that order in the exported file.

Sorting at the HAR generation boundary keeps the existing selection UX unchanged while ensuring every HAR export path produces chronological entries.

## User impact

The latest request now appears last in exported HAR files, regardless of the direction used to select requests.

## Validation

- `npm run test:unit` — 934 tests passed
- `git diff --check`
